### PR TITLE
Remove executor logic

### DIFF
--- a/src/Multisig.vy
+++ b/src/Multisig.vy
@@ -4,7 +4,7 @@
 EIP712DOMAINTYPE_HASH: constant(bytes32) = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)")
 NAME_HASH:             constant(bytes32) = keccak256("tiny multisig")
 VERSION_HASH:          constant(bytes32) = keccak256("1")
-TXTYPE_HASH:           constant(bytes32) = keccak256("MultiSigTransaction(address destination,uint256 value,bytes data,uint256 nonce,address executor)")
+TXTYPE_HASH:           constant(bytes32) = keccak256("MultiSigTransaction(address destination,uint256 value,bytes data,uint256 nonce)")
 SALT:                  constant(bytes32) = 0x129d390a401694aef5508ae83353e4124512a4c5bf5b10995b62abe1fb85b650
 MAX_OWNERS:            constant(uint256) = 16
 DOMAIN_SEPARATOR:      immutable(bytes32)
@@ -55,14 +55,12 @@ def exec( v: DynArray[uint256, MAX_OWNERS],
           s: DynArray[uint256, MAX_OWNERS],
           target: address, amount: uint256,
           data: Bytes[2000],
-          executor: address
         ):
     assert len(v) == len(r) \
        and len(r) == len(s) \
-       and len(s) == self.threshold, 'Num sigs err'
-    assert executor == msg.sender or executor == empty(address), 'err/wrong_executor'
+       and len(s) == self.threshold, 'err/num_sigs'
 
-    txn_hash: bytes32 = keccak256(_abi_encode(TXTYPE_HASH, target, amount, keccak256(data), self.nonce, executor))
+    txn_hash: bytes32 = keccak256(_abi_encode(TXTYPE_HASH, target, amount, keccak256(data), self.nonce))
     sum_hash: bytes32 = keccak256(concat(convert('\x19\x01', Bytes[2]), DOMAIN_SEPARATOR, txn_hash))
     msg_hash: bytes32 = self.prefix(sum_hash)
     last:     address = empty(address)

--- a/test/multisig-test.js
+++ b/test/multisig-test.js
@@ -8,7 +8,7 @@ const { send, wad } = require('minihat')
 const TestHarness = require('./test-harness')
 
 let DOMAIN_SEPARATOR
-const TXTYPE_HASH           = '0x77a02b8d4d89821b65796d535cba07669f292aede4f4a6e17753e6e3d2499732'
+const TXTYPE_HASH           = '0xe7beff35c01d1bb188c46fbae3d80f308d2600ba612c687a3e61446e0dffda0b'
 const NAME_HASH             = '0xe463279c76a26a807fc93adcd7da8c78758960944d3dd615283d0a9fa20efdc6'
 const VERSION_HASH          = '0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6'
 const EIP712DOMAINTYPE_HASH = '0xd87cd6ef79d4e2b95e15ce8abf732db51ec771f1ca2edccf22a46c729ac56472'
@@ -60,7 +60,6 @@ TestHarness.test('msig moves tokens', {
                 + utils.hexlify(eth_amt).slice(2).padStart(64, '0')
                 + utils.keccak256(data).slice(2)
                 + utils.hexlify(nonce).slice(2).padStart(64, '0')
-                + executor.slice(2).padStart(64, '0')
     tx_input = tx_input.toLowerCase()
     let tx_input_hash = utils.keccak256(tx_input)
     
@@ -78,7 +77,7 @@ TestHarness.test('msig moves tokens', {
         s_arr.push(split_sig.s)
     }
 
-    await send(multisig.exec, v_arr, r_arr, s_arr, rico.address, eth_amt, data, executor,  {gasLimit: 10000000})
+    await send(multisig.exec, v_arr, r_arr, s_arr, rico.address, eth_amt, data,  {gasLimit: 10000000})
 
     bob_rico_2 = await rico.balanceOf(bob.address)
     assert.equal(bob_rico_2.sub(rico_amt).eq(bob_rico_1), true)


### PR DESCRIPTION
Removes the logic of having a set executor for a call per #6 

Tests passing locally at HEAD commit.

```
(snek) multisig $>  git rev-parse HEAD
084cf1b667594322c00cd4e6f48ac9445383364c
(snek) multisig $> npm run test

> vymultisig@0.0.1 test
> snek test && cd test && node multisig-test.js

Successfully compiled .vy contracts in src/. Results saved to /Users/Dan/scontract/multisig/out/SrcOutput.json
Successfully compiled .vy contracts in test/. Results saved to /Users/Dan/scontract/multisig/out/TestOutput.json
Successfully compiled .vy contracts in /snapshot/snek/snek.vy. Results saved to /Users/Dan/scontract/multisig/out/SnekOutput.json
multisig.t::test_init PASSED
multisig.t::test_throw_high_threshold PASSED
multisig.t::test_throw_repeat_addresses PASSED
multisig.t::test_throw_address_order PASSED
multisig.t::test_throw_too_many_members PASSED
Passed 5/5
TAP version 13
# msig moves tokens
construct harness
bootstrap harness
in first test
ok 1 should be equal
ok 2 should be equal
close harness
# insufficient members
construct harness
bootstrap harness
close harness
# wrong members
construct harness
bootstrap harness
close harness
# too many members
construct harness
bootstrap harness
close harness
# too many members
construct harness
bootstrap harness
close harness
# repeated members
construct harness
bootstrap harness
close harness
# member addresses wrong order
construct harness
bootstrap harness
close harness
# fail create with threshold > members
construct harness
bootstrap harness
ok 3 should be equal
close harness
# fail create member addresses wrong order
construct harness
bootstrap harness
ok 4 should be equal
close harness

1..4
# tests 4
# pass  4

# ok
```